### PR TITLE
refactor: use async function and support egg@2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
   - '8'
+  - '9'
 install:
   - npm i npminstall && npminstall
 script:

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const parse = require('co-busboy');
-const co = require('co');
 
 module.exports = {
   /**
@@ -24,7 +23,7 @@ module.exports = {
    * get upload file stream
    * @example
    * ```js
-   * const stream = yield this.getFileStream();
+   * const stream = await ctx.getFileStream();
    * // get other fields
    * console.log(stream.fields);
    * ```
@@ -34,9 +33,9 @@ module.exports = {
    */
   getFileStream() {
     const ctx = this;
-    return co(function* () {
+    const readStream = async () => {
       const parts = ctx.multipart({ autoFields: true });
-      const stream = yield parts;
+      const stream = await parts();
       // stream not exists, treat as an exception
       if (!stream || !stream.filename) {
         ctx.throw(400, 'Can\'t found upload file');
@@ -60,6 +59,8 @@ module.exports = {
         stream.resume();
       });
       return stream;
-    });
+    };
+
+    return readStream();
   },
 };

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-    - nodejs_version: '6'
     - nodejs_version: '8'
+    - nodejs_version: '9'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "app.js"
   ],
   "ci": {
-    "version": "6, 8",
+    "version": "8, 9",
     "license": true
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/eggjs/egg-multipart#readme",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "files": [
     "app",
@@ -44,25 +44,24 @@
     "license": true
   },
   "dependencies": {
-    "co": "^4.6.0",
-    "co-busboy": "^1.3.1",
+    "co-busboy": "^1.4.0",
     "humanize-bytes": "^1.0.1"
   },
   "devDependencies": {
-    "autod": "^2.8.0",
-    "egg": "^1.5.0",
-    "egg-bin": "^4.0.4",
+    "autod": "^2.10.1",
+    "egg": "next",
+    "egg-bin": "^4.3.5",
     "egg-ci": "^1.8.0",
-    "egg-mock": "^3.8.0",
-    "eslint": "^4.1.0",
-    "eslint-config-egg": "^4.2.1",
+    "egg-mock": "^3.13.1",
+    "eslint": "^4.10.0",
+    "eslint-config-egg": "^5.1.1",
     "formstream": "^1.1.0",
     "is-type-of": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "mz": "^2.6.0",
+    "mz": "^2.7.0",
     "stream-wormhole": "^1.0.3",
     "supertest": "^3.0.0",
-    "urllib": "^2.22.0",
+    "urllib": "^2.25.1",
     "webstorm-disable-index": "^1.2.0"
   }
 }

--- a/test/fixtures/apps/multipart-with-whitelist/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-with-whitelist/app/controller/upload.js
@@ -3,10 +3,10 @@
 const path = require('path');
 const fs = require('fs');
 
-module.exports = function* () {
-  const parts = this.multipart();
+module.exports = async ctx => {
+  const parts = ctx.multipart();
   let part;
-  while ((part = yield parts) != null) {
+  while ((part = await parts()) != null) {
     if (Array.isArray(part)) {
       continue;
     } else {
@@ -14,9 +14,9 @@ module.exports = function* () {
     }
   }
 
-  const ws = fs.createWriteStream(path.join(this.app.config.logger.dir, 'multipart-test-file'));
+  const ws = fs.createWriteStream(path.join(ctx.app.config.logger.dir, 'multipart-test-file'));
   part.pipe(ws);
-  this.body = {
+  ctx.body = {
     filename: part.filename,
   };
 };

--- a/test/fixtures/apps/multipart/app/controller/upload.js
+++ b/test/fixtures/apps/multipart/app/controller/upload.js
@@ -15,9 +15,6 @@ module.exports = async ctx => {
     }
   }
 
-  // 并没有文件被上传，这时候需要根据业务需要做针对性的处理
-  // 例如 文件是必须字段，那么就报错
-  // 这里只是给出提示
   if (!part || !part.filename) {
     ctx.body = {
       message: 'no file',

--- a/test/fixtures/apps/upload-limit/app/router.js
+++ b/test/fixtures/apps/upload-limit/app/router.js
@@ -40,19 +40,19 @@ module.exports = app => {
     },
   };
 
-  app.get('/upload', function* () {
-    this.set('x-csrf', this.csrf);
-    this.body = 'hi';
+  app.get('/upload', async ctx => {
+    ctx.set('x-csrf', ctx.csrf);
+    ctx.body = 'hi';
   });
 
-  app.post('/upload', function* () {
-    const stream = yield this.getFileStream();
+  app.post('/upload', async ctx => {
+    const stream = await ctx.getFileStream();
     const name = 'egg-multipart-test/' + process.version + '-' + Date.now() + '-' + path.basename(stream.filename);
-    const result = yield this.oss.put(name, stream);
+    const result = await ctx.oss.put(name, stream);
     if (name.includes('not-handle-error-event-and-mock-stream-error')) {
       process.nextTick(() => stream.emit('error', new Error('mock stream unhandle error')));
     }
-    this.body = {
+    ctx.body = {
       name: result.name,
       url: result.url,
       status: result.res.status,

--- a/test/fixtures/apps/upload-one-file/app/controller/async.js
+++ b/test/fixtures/apps/upload-one-file/app/controller/async.js
@@ -3,30 +3,19 @@
 const co = require('co');
 const path = require('path');
 
-const __awaiter = (this && this.__awaiter) || function(thisArg, _arguments, P, generator) {
-  return new (P || (P = Promise))(function(resolve, reject) {
-    function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-    function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
-    function step(result) { result.done ? resolve(result.value) : new P(function(resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-    step((generator = generator.apply(thisArg, _arguments)).next());
-  });
-};
-
 module.exports = app => {
   return class UploadController extends app.Controller {
-    async() {
+    async async() {
       const ctx = this.ctx;
-      return __awaiter(this, void 0, void 0, function* () {
-        const stream = yield ctx.getFileStream();
-        const name = 'egg-multipart-test/' + process.version + '-' + Date.now() + '-' + path.basename(stream.filename);
-        const result = yield ctx.oss.put(name, stream);
-        ctx.body = {
-          name: result.name,
-          url: result.url,
-          status: result.res.status,
-          fields: stream.fields,
-        };
-      });
+      const stream = await ctx.getFileStream();
+      const name = 'egg-multipart-test/' + process.version + '-' + Date.now() + '-' + path.basename(stream.filename);
+      const result = await ctx.oss.put(name, stream);
+      ctx.body = {
+        name: result.name,
+        url: result.url,
+        status: result.res.status,
+        fields: stream.fields,
+      };
     }
   };
 };

--- a/test/fixtures/apps/whitelist-function/app/controller/upload.js
+++ b/test/fixtures/apps/whitelist-function/app/controller/upload.js
@@ -3,10 +3,11 @@
 const path = require('path');
 const fs = require('fs');
 
+// keep one generator function test case
 module.exports = function* () {
   const parts = this.multipart();
   let part;
-  while ((part = yield parts) != null) {
+  while ((part = yield parts()) != null) {
     if (Array.isArray(part)) {
       continue;
     } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

https://github.com/eggjs/egg/issues/1564

此处有要注意的地方，只能通过 `await parts()` 而不能 `await parts` 来实现获取多个上传文件。但是在 generator function 中，仍然可以使用 `yield parts`