### PR TITLE
fix:egg-multipart and changes docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ module.exports = Class UploadController extends Controller {
       },
       "checkFile": "<Function checkFile>"
     });
-     // will append to this.app.config.multipartParseOptions
+     // will assign this.app.config.multipartParseOptions
     */
     let part;
     while ((part = await parts()) != null) {

--- a/README.md
+++ b/README.md
@@ -174,6 +174,22 @@ module.exports = Class UploadController extends Controller {
   async upload() {
     const ctx = this.ctx;
     const parts = ctx.multipart();
+    /**
+    //ctx custom config
+    const parts = ctx.multipart({
+      "autoFields": false,
+      "defCharset": "utf8",
+      "limits": {
+        "fieldNameSize": Number, // unit b
+        "fieldSize": Number, // unit b, 102400 ==> 100kb
+        "fields": Number,
+        "fileSize": Number, // unit b,10485760 ==> 10mb
+        "files": Number
+      },
+      "checkFile": "<Function checkFile>"
+    });
+     // will append to this.app.config.multipartParseOptions
+    */
     let part;
     while ((part = await parts()) != null) {
       if (part.length) {

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -15,7 +15,10 @@ module.exports = {
       this.throw(400, 'Content-Type must be multipart/*');
     }
     const parseOptions = {};
+    const limits = {};
+    Object.assign(limits, this.app.config.multipartParseOptions.limits, (options && options.limits) || {});
     Object.assign(parseOptions, this.app.config.multipartParseOptions, options);
+    parseOptions.limits = limits;
     return parse(this, parseOptions);
   },
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
ctx.multipart(options)

##### Description of change
<!-- Provide a description of the change below this comment. -->
fix: options.limits override this.app.config.multipartParseOptions.limits
docs: ctx custom config


```sell
tusmdeMacBook-Pro-2:egg-multipart tusm$ npm test

> egg-multipart@2.0.0 test /Users/tusm/github/egg-multipart
> npm run lint -- --fix && npm run test-local


> egg-multipart@2.0.0 lint /Users/tusm/github/egg-multipart
> eslint . "--fix"


> egg-multipart@2.0.0 test-local /Users/tusm/github/egg-multipart
> egg-bin test



  test/multipart.test.js
    multipart
      ✓ should upload with csrf
      ✓ should upload.json with ctoken
      ✓ should handle unread stream and return error response
      ✓ should throw 400 when extname wrong
      ✓ should not throw 400 when file not speicified
      ✓ should not throw 400 when file stream empty
      ✓ should upload when extname speicified in fileExtensions
      ✓ should upload when extname speicified in fileExtensions and extname is in upper case
      ✓ should 400 upload with wrong content-type
      ✓ should 400 upload.json with wrong content-type
    whitelist
      ✓ should upload when extname speicified in whitelist
      ✓ should upload when extname speicified in whitelist and extname is in upper case
      ✓ should throw 400 when extname speicified in fileExtensions, but not in whitelist
    whitelist-function
      ✓ should upload when extname pass whitelist function
      ✓ should throw 400 when extname not match whitelist function
      ✓ should throw 400 when whitelist function throw error
    upload one file
      ✓ should handle one upload file in simple way
      ✓ should handle one upload file in simple way with async function controller
      ✓ should handle one upload file and all fields
      ✓ should 400 when no file upload
      ✓ should 400 when no file speicified
    upload over fileSize limit
read stream error: MultipartFileTooLargeError: Request file too large
      ✓ should show error
      ✓ should ignore error when stream not handle error event
      ✓ should ignore stream next errors after limit event fire


  24 passing (1s)

```