### PR TITLE
feat: getFileStream() can accept non file request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - '8'
-  - '9'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Alibaba Group Holding Limited and other contributors.
+Copyright (c) 2017-present Alibaba Group Holding Limited and other contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ module.exports = Class UploadController extends Controller {
   async uploadNotRequiredFile() {
     const ctx = this.ctx;
     // file not required
-    const stream = await ctx.getFileStream({ required: false });
+    const stream = await ctx.getFileStream({ requireFile: false });
     let result;
     if (stream.filename) {
       const name = 'egg-multipart-test/' + path.basename(stream.filename);

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ const Controller = require('egg').Controller;
 module.exports = Class UploadController extends Controller {
   async upload() {
     const ctx = this.ctx;
+    // file not exists will response 400 error
     const stream = await ctx.getFileStream();
     const name = 'egg-multipart-test/' + path.basename(stream.filename);
     let result;
@@ -146,6 +147,33 @@ module.exports = Class UploadController extends Controller {
 
     ctx.body = {
       url: result.url,
+      // process form fields by `stream.fields`
+      fields: stream.fields,
+    };
+  }
+
+  async uploadNotRequiredFile() {
+    const ctx = this.ctx;
+    // file not required
+    const stream = await ctx.getFileStream({ required: false });
+    let result;
+    if (stream.filename) {
+      const name = 'egg-multipart-test/' + path.basename(stream.filename);
+      try {
+        // process file or upload to cloud storage
+        result = await ctx.oss.put(name, stream);
+      } catch (err) {
+        // must consume the stream, otherwise browser will be stuck.
+        await sendToWormhole(stream);
+        throw err;
+      }
+    } else {
+      // must consume the empty stream
+      await sendToWormhole(stream);
+    }
+
+    ctx.body = {
+      url: result && result.url,
       // process form fields by `stream.fields`
       fields: stream.fields,
     };

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -36,7 +36,7 @@ module.exports = {
    * ```
    * @method Context#getFileStream
    * @param {Object} options
-   *  - {Boolean} options.required - required file submit, default is true
+   *  - {Boolean} options.requireFile - required file submit, default is true
    * @return {ReadStream} stream
    * @since 1.0.0
    */
@@ -45,7 +45,7 @@ module.exports = {
     const parts = this.multipart({ autoFields: true });
     let stream = await parts();
 
-    if (options.required !== false) {
+    if (options.requireFile !== false) {
       // stream not exists, treat as an exception
       if (!stream || !stream.filename) {
         this.throw(400, 'Can\'t found upload file');

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - nodejs_version: '8'
-    - nodejs_version: '9'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "app.js"
   ],
   "ci": {
-    "version": "8, 9",
+    "version": "8, 10",
     "license": true
   },
   "dependencies": {
@@ -48,20 +48,20 @@
     "humanize-bytes": "^1.0.1"
   },
   "devDependencies": {
-    "autod": "^2.10.1",
-    "egg": "next",
-    "egg-bin": "^4.3.5",
+    "autod": "^3.0.1",
+    "egg": "^2.9.1",
+    "egg-bin": "^4.8.1",
     "egg-ci": "^1.8.0",
-    "egg-mock": "^3.13.1",
-    "eslint": "^4.10.0",
-    "eslint-config-egg": "^5.1.1",
+    "egg-mock": "^3.18.0",
+    "eslint": "^5.2.0",
+    "eslint-config-egg": "^7.0.0",
     "formstream": "^1.1.0",
     "is-type-of": "^1.0.0",
     "mkdirp": "^0.5.1",
     "mz": "^2.7.0",
     "stream-wormhole": "^1.0.3",
     "supertest": "^3.0.0",
-    "urllib": "^2.25.1",
+    "urllib": "^2.29.1",
     "webstorm-disable-index": "^1.2.0"
   }
 }

--- a/test/fixtures/apps/upload-one-file/app/controller/async.js
+++ b/test/fixtures/apps/upload-one-file/app/controller/async.js
@@ -17,5 +17,26 @@ module.exports = app => {
         fields: stream.fields,
       };
     }
+
+    async allowEmpty() {
+      const ctx = this.ctx;
+      const stream = await ctx.getFileStream({ required: false });
+      if (stream.filename) {
+        const name = 'egg-multipart-test/' + process.version + '-' + Date.now() + '-' + path.basename(stream.filename);
+        const result = await ctx.oss.put(name, stream);
+        ctx.body = {
+          name: result.name,
+          url: result.url,
+          status: result.res.status,
+          fields: stream.fields,
+        };
+        return;
+      }
+
+      stream.resume();
+      ctx.body = {
+        fields: stream.fields,
+      };
+    }
   };
 };

--- a/test/fixtures/apps/upload-one-file/app/controller/async.js
+++ b/test/fixtures/apps/upload-one-file/app/controller/async.js
@@ -20,7 +20,7 @@ module.exports = app => {
 
     async allowEmpty() {
       const ctx = this.ctx;
-      const stream = await ctx.getFileStream({ required: false });
+      const stream = await ctx.getFileStream({ requireFile: false });
       if (stream.filename) {
         const name = 'egg-multipart-test/' + process.version + '-' + Date.now() + '-' + path.basename(stream.filename);
         const result = await ctx.oss.put(name, stream);

--- a/test/fixtures/apps/upload-one-file/app/router.js
+++ b/test/fixtures/apps/upload-one-file/app/router.js
@@ -53,4 +53,6 @@ module.exports = app => {
   });
 
   app.post('/upload/async', 'async.async');
+
+  app.post('/upload/allowEmpty', 'async.allowEmpty');
 };


### PR DESCRIPTION
```js
const stream = await ctx.getFileStream({ required: false });
if (stream.filename) {
  console.log('uploaded ' + stream.filename);
} else {
  console.log('file not exists');
}
```

closes https://github.com/eggjs/egg/issues/2178

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
