### PR TITLE
feat: compatibility without dot at fileExtensions

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,10 @@ module.exports = app => {
     options.whitelist = options.whitelist.map(extname => extname.toLowerCase());
     checkExt = filename => options.whitelist.includes(path.extname(filename).toLowerCase());
   } else {
+    const fileExtensions = (options.fileExtensions || []).map(extname => {
+      return extname.startsWith('.') ? extname : `.${extname}`;
+    });
+
     // default extname whitelist
     const whitelist = [
       // images
@@ -45,7 +49,7 @@ module.exports = app => {
       '.mp4',
       '.avi',
     ]
-      .concat(options.fileExtensions || [])
+      .concat(fileExtensions)
       .map(extname => extname.toLowerCase());
 
     checkExt = filename => whitelist.includes(path.extname(filename).toLowerCase());

--- a/test/fixtures/apps/multipart/config/config.default.js
+++ b/test/fixtures/apps/multipart/config/config.default.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.multipart = {
-  fileExtensions: ['.foo', '.BAR'],
+  fileExtensions: ['.foo', '.BAR', 'abc' ],
 };
 
 exports.keys = 'multipart';

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -203,6 +203,21 @@ describe('test/multipart.test.js', () => {
       assert(data.filename === 'bar.BAR');
     });
 
+    it('should upload when extname speicified in fileExtensions and extname is missing dot', function* () {
+      const form = formstream();
+      form.file('file', __filename, 'bar.abc');
+      const headers = form.headers();
+      const res = yield urllib.request(host + '/upload.json', {
+        method: 'POST',
+        headers,
+        stream: form,
+      });
+
+      assert(res.status === 200);
+      const data = JSON.parse(res.data);
+      assert(data.filename === 'bar.abc');
+    });
+
     it('should 400 upload with wrong content-type', function* () {
       const res = yield urllib.request(host + '/upload', {
         method: 'POST',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

fileExtensions 配置的后缀名，可以省掉 `.`

现在 sff 配置是：

```yaml
    fileExtensions:
      - .txt
      - .json
```

该特性可以使得：

```yaml
    fileExtensions:
      - txt
      - json
```