### PR TITLE
fix: support extname not speicified

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ module.exports = app => {
     checkExt = filename => options.whitelist.includes(path.extname(filename).toLowerCase());
   } else {
     const fileExtensions = (options.fileExtensions || []).map(extname => {
-      return extname.startsWith('.') ? extname : `.${extname}`;
+      return (extname.startsWith('.') || extname === '') ? extname : `.${extname}`;
     });
 
     // default extname whitelist

--- a/test/fixtures/apps/multipart/config/config.default.js
+++ b/test/fixtures/apps/multipart/config/config.default.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.multipart = {
-  fileExtensions: ['.foo', '.BAR', 'abc' ],
+  fileExtensions: ['.foo', '.BAR', 'abc', '' ],
 };
 
 exports.keys = 'multipart';

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -218,6 +218,21 @@ describe('test/multipart.test.js', () => {
       assert(data.filename === 'bar.abc');
     });
 
+    it('should upload when extname is not speicified', function* () {
+      const form = formstream();
+      form.file('file', __filename, 'bar');
+      const headers = form.headers();
+      const res = yield urllib.request(host + '/upload.json', {
+        method: 'POST',
+        headers,
+        stream: form,
+      });
+
+      assert(res.status === 200);
+      const data = JSON.parse(res.data);
+      assert(data.filename === 'bar');
+    });
+
     it('should 400 upload with wrong content-type', function* () {
       const res = yield urllib.request(host + '/upload', {
         method: 'POST',


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines


##### Description of change
2.10.0之前，当上传文件没有扩展名时，可以设置fileExtensions：['']
2.10.0之后，因为支持扩展名没有添加`.`的情况，导致没有扩展名时，返回400。
之前的issue  https://github.com/eggjs/egg/issues/774
