### PR TITLE
fix: 修复 whiteList ts类型注释

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ declare module 'egg' {
       fields?: number;
       fileSize?: string|number;
       files?: number;
-      whitelist?: (() => string[])|string[];
+      whitelist?: ((filename: string) => boolean)|string[];
       fileExtensions?: string[];
       tmpdir?: string;
       cleanSchedule?: ScheduleOptions;


### PR DESCRIPTION
错误信息

![image](https://user-images.githubusercontent.com/20502762/77754238-e12c3500-7065-11ea-8ed4-d742cc827aaa.png)

此处代码贡献只是做了类型修复，就不做性能测试啥的了。

源码中一共有三种情况

1. `whiteList` 是一个函数
2. `whiteList` 是一个数组
3. `whiteList` 为空

![image](https://user-images.githubusercontent.com/20502762/77754648-ad9dda80-7066-11ea-9e94-58650d003c13.png)

然后原本的类型注释是这样的

```ts
whitelist?: (() => string[])|string[];
```


这里应该为函数返回 `boolean` 属性才对。

```ts
whitelist?: ((filename: string) => boolean)|string[];
```
