### PR TITLE
feat: support `for await...of`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ module.exports = class extends Controller {
 
 If you're well-known about know the Node.js Stream work, you should use the `stream` mode.
 
-### Use with `for await of`
+### Use with `for await...of`
 
 ```html
 <form method="POST" action="/upload?_csrf={{ ctx.csrf | safe }}" enctype="multipart/form-data">

--- a/README.md
+++ b/README.md
@@ -246,7 +246,68 @@ module.exports = class extends Controller {
 
 If you're well-known about know the Node.js Stream work, you should use the `stream` mode.
 
-### Upload One File
+### Use with `for await of`
+
+```html
+<form method="POST" action="/upload?_csrf={{ ctx.csrf | safe }}" enctype="multipart/form-data">
+  title: <input name="title" />
+  file1: <input name="file1" type="file" />
+  file2: <input name="file2" type="file" />
+  <button type="submit">Upload</button>
+</form>
+```
+
+Controller which hanlder `POST /upload`:
+
+```js
+// app/controller/upload.js
+const { Controller } = require('egg');
+const fs = require('fs');
+const stream = require('stream');
+const util = require('util');
+const pipeline = util.promisify(stream.pipeline);
+
+module.exports = class UploadController extends Controller {
+  async upload() {
+    const parts = this.ctx.multipart();
+    const fields = {};
+    const files = {};
+
+    for await (const part of parts) {
+      if (Array.isArray(part)) {
+        // fields
+        console.log('field: ' + part[0]);
+        console.log('value: ' + part[1]);
+      } else {
+        // otherwise, it's a stream
+        const { filename, fieldname, encoding, mime } = part;
+
+        // user click `upload` before choose a file, `part` will be file stream, but `part.filename` is empty must handler this, such as log error.
+        if (!filename) continue;
+
+        console.log('field: ' + fieldname);
+        console.log('filename: ' + filename);
+        console.log('encoding: ' + encoding);
+        console.log('mime: ' + mime);
+
+        // how to handler?
+        // 1. save to tmpdir with pipeline
+        // 2. or send to oss
+        // 3. or just consume it with another for await
+
+        // WARNING: You should almost never use the origin filename as it could contain malicious input.
+        const targetPath = path.join(os.tmpdir(), uuid.v4() + path.extname(meta.filename));
+        await pipeline(part, createWriteStream(targetPath)); // use `pipeline` not `pipe`
+      }
+    }
+
+    this.ctx.body = 'ok';
+  }
+};
+```
+
+
+### Upload One File (DEPRECATED)
 
 You can got upload stream by `ctx.getFileStream*()`.
 
@@ -258,7 +319,7 @@ You can got upload stream by `ctx.getFileStream*()`.
 </form>
 ```
 
-Controller which hanlder `POST /upload`:
+Controller which handler `POST /upload`:
 
 ```js
 // app/controller/upload.js
@@ -305,7 +366,7 @@ module.exports = class extends Controller {
 };
 ```
 
-### Upload Multiple Files
+### Upload Multiple Files (DEPRECATED)
 
 ```html
 <form method="POST" action="/upload?_csrf={{ ctx.csrf | safe }}" enctype="multipart/form-data">

--- a/test/file-mode.test.js
+++ b/test/file-mode.test.js
@@ -224,7 +224,7 @@ describe('test/file-mode.test.js', () => {
   });
 
   // fieldNameSize is TODO on busboy
-  // see https://github.com/mscdex/busboy/blob/master/lib/types/multipart.js#L5
+  // see https://github.com/mscdex/busboy/blob/v0.3.1/lib/types/multipart.js#L5
   it.skip('should throw error when request field name size limit', async () => {
     const form = formstream();
     form.field('b'.repeat(101), 'a');

--- a/test/fixtures/apps/multipart-for-await/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-for-await/app/controller/upload.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const path = require('path');
+const { Controller } = require('egg');
+
+module.exports = class UploadController extends Controller {
+  async index() {
+    const parts = this.ctx.multipart();
+    const fields = {};
+    const files = {};
+
+    for await (const part of parts) {
+      if (Array.isArray(part)) {
+        const [ name, value ] = part;
+        fields[name] = value;
+      } else {
+        const { filename, fieldname } = part;
+        console.log('###', part.truncated)
+        let content = '';
+        for await(const chunk of part) {
+          content += chunk.toString();
+        }
+        files[fieldname] = {
+          fileName: filename,
+          content,
+        }
+      }
+    }
+
+    this.ctx.body = { fields, files };
+  }
+};

--- a/test/fixtures/apps/multipart-for-await/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-for-await/app/controller/upload.js
@@ -15,7 +15,6 @@ module.exports = class UploadController extends Controller {
         fields[name] = value;
       } else {
         const { filename, fieldname } = part;
-        console.log('###', part.truncated)
         let content = '';
         for await(const chunk of part) {
           content += chunk.toString();

--- a/test/fixtures/apps/multipart-for-await/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-for-await/app/controller/upload.js
@@ -2,6 +2,9 @@
 
 const path = require('path');
 const { Controller } = require('egg');
+const stream = require('stream');
+const util = require('util');
+const pipeline = util.promisify(stream.pipeline);
 
 module.exports = class UploadController extends Controller {
   async index() {
@@ -9,16 +12,28 @@ module.exports = class UploadController extends Controller {
     const fields = {};
     const files = {};
 
+    const shouldMockError = !!this.ctx.query.mock_error;
+
     for await (const part of parts) {
       if (Array.isArray(part)) {
         const [ name, value ] = part;
         fields[name] = value;
       } else {
         const { filename, fieldname } = part;
+
         let content = '';
-        for await(const chunk of part) {
-          content += chunk.toString();
-        }
+        await pipeline(part,
+          new stream.Writable({
+            write(chunk, encding, callback) {
+              content += chunk.toString();
+              if (shouldMockError) {
+                return callback(new Error('mock error'));
+              }
+              setImmediate(callback);
+            },
+          }),
+        );
+
         files[fieldname] = {
           fileName: filename,
           content,

--- a/test/fixtures/apps/multipart-for-await/app/router.js
+++ b/test/fixtures/apps/multipart-for-await/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = app => {
+  app.post('/upload', app.controller.upload.index);
+};

--- a/test/fixtures/apps/multipart-for-await/app/views/home.html
+++ b/test/fixtures/apps/multipart-for-await/app/views/home.html
@@ -1,0 +1,5 @@
+<form method="POST" action="/upload?_csrf={{ ctx.csrf | safe }}" enctype="multipart/form-data">
+  title: <input name="title" />
+  file: <input name="file" type="file" />
+  <button type="submit">上传</button>
+</form>

--- a/test/fixtures/apps/multipart-for-await/config/config.default.js
+++ b/test/fixtures/apps/multipart-for-await/config/config.default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.multipart = {
+  fieldSize: 10,
+  fieldNameSize: 10,
+  fileSize: 1024,
+};
+
+exports.keys = 'multipart';

--- a/test/fixtures/apps/multipart-for-await/package.json
+++ b/test/fixtures/apps/multipart-for-await/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "multipart-for-await"
+}

--- a/test/fixtures/testfile.js
+++ b/test/fixtures/testfile.js
@@ -1,0 +1,1 @@
+this is a test file

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const assert = require('assert');
+const formstream = require('formstream');
+const urllib = require('urllib');
+const path = require('path');
+const mock = require('egg-mock');
+
+describe.only('test/multipart-for-await.test.js', () => {
+  let app;
+  let server;
+  let host;
+  before(async () => {
+    app = mock.app({
+      baseDir: 'apps/multipart-for-await',
+    });
+    await app.ready();
+    server = app.listen();
+    host = 'http://127.0.0.1:' + server.address().port;
+  });
+  after(() => app.close());
+  after(() => server.close());
+  beforeEach(() => app.mockCsrf());
+  afterEach(mock.restore);
+
+  it('should suport for await...of', async () => {
+    const form = formstream();
+    form.field('foo', 'bar');
+    form.field('love', 'egg');
+    form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
+    form.file('file2', path.join(__dirname, 'fixtures/testfile.js'));
+
+    const res = await urllib.request(host + '/upload', {
+      method: 'POST',
+      headers: form.headers(),
+      stream: form,
+      dataType: 'json',
+    });
+
+    const data = res.data;
+    console.log(data);
+    assert(data.fields.foo === 'bar');
+    assert(data.fields.love === 'egg');
+    assert(data.files.file1.fileName === '中文名.js');
+    assert(data.files.file1.content === 'hello\n');
+    assert(data.files.file2.fileName === 'testfile.js');
+    assert(data.files.file2.content === 'this is a test file\n');
+  });
+
+  describe('should throw when limit', () => {
+    it('limit fileSize', async () => {
+      const form = formstream();
+      form.field('foo', 'bar');
+      form.field('love', 'egg');
+      // form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
+      form.file('file2', path.join(__dirname, 'fixtures/bigfile.js'));
+
+      const res = await urllib.request(host + '/upload', {
+        method: 'POST',
+        headers: form.headers(),
+        stream: form,
+        dataType: 'json',
+      });
+
+      const { data, status } = res;
+      assert(status === 413);
+      assert(data.message === 'Reach fileSize limit');
+    });
+
+    it('limit fieldSize', async () => {
+      const form = formstream();
+      form.field('foo', 'bar');
+      form.field('love', 'eggaaaaaaaaaaaaa');
+      form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
+      form.file('file2', path.join(__dirname, 'fixtures/testfile.js'));
+
+      const res = await urllib.request(host + '/upload', {
+        method: 'POST',
+        headers: form.headers(),
+        stream: form,
+        dataType: 'json',
+      });
+
+      const { data, status } = res;
+      assert(status === 413);
+      assert(data.message === 'Reach fieldSize limit');
+    });
+
+    // TODO: still not support at busboy 1.x (only support at urlencoded)
+    // https://github.com/mscdex/busboy/blob/v0.3.1/lib/types/multipart.js#L5
+    // https://github.com/mscdex/busboy/blob/master/lib/types/multipart.js#L251
+    it.skip('limit fieldNameSize', async () => {
+      const form = formstream();
+      form.field('fooaaaaaaaaaaaaaaa', 'bar');
+      form.field('love', 'egg');
+      form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
+      form.file('file2', path.join(__dirname, 'fixtures/testfile.js'));
+
+      const res = await urllib.request(host + '/upload', {
+        method: 'POST',
+        headers: form.headers(),
+        stream: form,
+        dataType: 'json',
+      });
+
+      const { data, status } = res;
+      assert(status === 413);
+      assert(data.message === 'Reach fieldNameSize limit');
+    });
+  });
+});

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -6,7 +6,7 @@ const urllib = require('urllib');
 const path = require('path');
 const mock = require('egg-mock');
 
-describe('test/multipart-for-await.test.js', () => {
+describe.only('test/multipart-for-await.test.js', () => {
   let app;
   let server;
   let host;
@@ -38,13 +38,29 @@ describe('test/multipart-for-await.test.js', () => {
     });
 
     const data = res.data;
-    console.log(data);
+    // console.log(data);
     assert(data.fields.foo === 'bar');
     assert(data.fields.love === 'egg');
     assert(data.files.file1.fileName === '中文名.js');
     assert(data.files.file1.content.includes('hello'));
     assert(data.files.file2.fileName === 'testfile.js');
     assert(data.files.file2.content.includes('this is a test file'));
+  });
+
+  it('should auto consumed file stream on error throw', async () => {
+    const form = formstream();
+    form.field('foo', 'bar');
+    form.field('love', 'egg');
+    form.file('file2', path.join(__dirname, 'fixtures/testfile.js'));
+
+    const res = await urllib.request(host + '/upload?mock_error=true', {
+      method: 'POST',
+      headers: form.headers(),
+      stream: form,
+      dataType: 'json',
+    });
+
+    assert(res.data.message === 'mock error');
   });
 
   describe('should throw when limit', () => {

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -44,7 +44,7 @@ describe('test/multipart-for-await.test.js', () => {
     assert(data.files.file1.fileName === '中文名.js');
     assert(data.files.file1.content.includes('hello'));
     assert(data.files.file2.fileName === 'testfile.js');
-    assert(data.files.file2.content === 'this is a test file\n');
+    assert(data.files.file2.content.includes('this is a test file'));
   });
 
   describe('should throw when limit', () => {

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -42,7 +42,7 @@ describe('test/multipart-for-await.test.js', () => {
     assert(data.fields.foo === 'bar');
     assert(data.fields.love === 'egg');
     assert(data.files.file1.fileName === '中文名.js');
-    assert(data.files.file1.content === 'hello\n');
+    assert(data.files.file1.content.includes('hello'));
     assert(data.files.file2.fileName === 'testfile.js');
     assert(data.files.file2.content === 'this is a test file\n');
   });
@@ -52,7 +52,7 @@ describe('test/multipart-for-await.test.js', () => {
       const form = formstream();
       form.field('foo', 'bar');
       form.field('love', 'egg');
-      // form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
+      form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
       form.file('file2', path.join(__dirname, 'fixtures/bigfile.js'));
 
       const res = await urllib.request(host + '/upload', {

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -6,7 +6,7 @@ const urllib = require('urllib');
 const path = require('path');
 const mock = require('egg-mock');
 
-describe.only('test/multipart-for-await.test.js', () => {
+describe('test/multipart-for-await.test.js', () => {
   let app;
   let server;
   let host;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

support `for await...of`

```js
// app/controller/upload.js
const { Controller } = require('egg');
const fs = require('fs');
const stream = require('stream');
const util = require('util');
const pipeline = util.promisify(stream.pipeline);

module.exports = class UploadController extends Controller {
  async upload() {
    const parts = this.ctx.multipart();
    const fields = {};
    const files = {};

    for await (const part of parts) {
      if (Array.isArray(part)) {
        // fields
        console.log('field: ' + part[0]);
        console.log('value: ' + part[1]);
      } else {
        // otherwise, it's a stream
        const { filename, fieldname, encoding, mime } = part;

        // user click `upload` before choose a file, `part` will be file stream, but `part.filename` is empty must handler this, such as log error.
        if (!filename) continue;

        console.log('field: ' + fieldname);
        console.log('filename: ' + filename);
        console.log('encoding: ' + encoding);
        console.log('mime: ' + mime);

        // how to handler?
        // 1. save to tmpdir with pipeline
        // 2. or send to oss
        // 3. or just consume it with another for await

        // WARNING: You should almost never use the origin filename as it could contain malicious input.
        const targetPath = path.join(os.tmpdir(), uuid.v4() + path.extname(meta.filename));
        await pipeline(part, createWriteStream(targetPath)); // use `pipeline` not `pipe`
      }
    }

    this.ctx.body = 'ok';
  }
};
```