### PR TITLE
refactor: saveRequestFiles with for-await-for

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,16 +282,6 @@ module.exports = class UploadController extends Controller {
         // otherwise, it's a stream
         const { filename, fieldname, encoding, mime } = part;
 
-        // user click `upload` before choose a file, `part` will be file stream, but `part.filename` is empty must handler this, such as log error.
-        if (!filename) {
-          await pipeline(part, new stream.Writable({
-            write(chunk, encding, callback) {
-              setImmediate(callback);
-            }
-          });
-          continue;
-        }
-
         console.log('field: ' + fieldname);
         console.log('filename: ' + filename);
         console.log('encoding: ' + encoding);

--- a/README.md
+++ b/README.md
@@ -283,7 +283,14 @@ module.exports = class UploadController extends Controller {
         const { filename, fieldname, encoding, mime } = part;
 
         // user click `upload` before choose a file, `part` will be file stream, but `part.filename` is empty must handler this, such as log error.
-        if (!filename) continue;
+        if (!filename) {
+          await pipeline(part, new stream.Writable({
+            write(chunk, encding, callback) {
+              setImmediate(callback);
+            }
+          });
+          continue;
+        }
 
         console.log('field: ' + fieldname);
         console.log('filename: ' + filename);
@@ -296,7 +303,7 @@ module.exports = class UploadController extends Controller {
         // 3. or just consume it with another for await
 
         // WARNING: You should almost never use the origin filename as it could contain malicious input.
-        const targetPath = path.join(os.tmpdir(), uuid.v4() + path.extname(meta.filename));
+        const targetPath = path.join(os.tmpdir(), uuid.v4() + path.extname(filename));
         await pipeline(part, createWriteStream(targetPath)); // use `pipeline` not `pipe`
       }
     }

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -103,6 +103,10 @@ module.exports = {
           const filepath = path.join(storedir, uuid.v4() + path.extname(meta.filename));
           const target = createWriteStream(filepath);
           await pipeline(part, target);
+
+          // truncated is only set true after begin consume the stream
+          if (part.truncated) limit('Request_fileSize_limit', 'Reach fileSize limit');
+
           // https://github.com/mscdex/busboy/blob/master/lib/types/multipart.js#L221
           meta.filepath = filepath;
           requestFiles.push(meta);

--- a/app/schedule/clean_tmpdir.js
+++ b/app/schedule/clean_tmpdir.js
@@ -5,7 +5,7 @@ const fs = require('fs').promises;
 const dayjs = require('dayjs');
 
 module.exports = app => {
-  return class CleanTmpdir extends (app.Subscription || app.BaseContextClass) {
+  return class CleanTmpdir extends app.Subscription {
     static get schedule() {
       return {
         type: 'worker',
@@ -23,8 +23,8 @@ module.exports = app => {
           await fs.rm(dir, { force: true, recursive: true });
           ctx.coreLogger.info('[egg-multipart:CleanTmpdir:success] tmpdir: %j has been removed', dir);
         } catch (err) {
-          ctx.coreLogger.error('[egg-multipart:CleanTmpdir:error] remove tmpdir: %j error: %s',
-            dir, err);
+          /* c8 ignore next 3 */
+          ctx.coreLogger.error('[egg-multipart:CleanTmpdir:error] remove tmpdir: %j error: %s', dir, err);
           ctx.coreLogger.error(err);
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "test": "npm run lint -- --fix && npm run test-local",
     "test-local": "egg-bin test",
-    "cov": "egg-bin cov",
+    "cov": "egg-bin cov --c8-report",
     "ci": "egg-bin pkgfiles && npm run lint && npm run cov",
     "pkgfiles": "egg-bin pkgfiles"
   },

--- a/test/dynamic-option.test.js
+++ b/test/dynamic-option.test.js
@@ -37,6 +37,7 @@ describe('test/dynamic-option.test.js', () => {
       method: 'POST',
       headers,
       stream: form,
+      // dataType: 'json',
     });
 
     assert(res.status === 413);

--- a/test/file-mode-limit-filesize-per-request.test.js
+++ b/test/file-mode-limit-filesize-per-request.test.js
@@ -63,7 +63,6 @@ describe('test/file-mode-limit-filesize-per-request.test.js', () => {
       stream: form,
       dataType: 'json',
     });
-
     assert(res.status === 413);
     // console.log(res.data);
     assert(res.data.code === 'Request_fileSize_limit');

--- a/test/file-mode-limit-filesize-per-request.test.js
+++ b/test/file-mode-limit-filesize-per-request.test.js
@@ -64,7 +64,6 @@ describe('test/file-mode-limit-filesize-per-request.test.js', () => {
       dataType: 'json',
     });
     assert(res.status === 413);
-    // console.log(res.data);
     assert(res.data.code === 'Request_fileSize_limit');
     assert(res.data.message === 'Reach fileSize limit');
   });

--- a/test/file-mode.test.js
+++ b/test/file-mode.test.js
@@ -293,7 +293,7 @@ describe('test/file-mode.test.js', () => {
     });
 
     assert(res.status === 500);
-    assert(res.data.toString().includes('TypeError: the multipart request can\'t be consumed twice'));
+    assert(res.data.toString().includes('the multipart request can\'t be consumed twice'));
   });
 
   it('should use cleanupRequestFiles after request end', async () => {

--- a/test/fixtures/apps/file-mode/config/config.default.js
+++ b/test/fixtures/apps/file-mode/config/config.default.js
@@ -2,6 +2,7 @@
 
 exports.multipart = {
   mode: 'file',
+  // fileSize: 10,
 };
 
 exports.keys = 'multipart';

--- a/test/fixtures/apps/multipart-for-await/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-for-await/app/controller/upload.js
@@ -8,11 +8,12 @@ const pipeline = util.promisify(stream.pipeline);
 
 module.exports = class UploadController extends Controller {
   async index() {
-    const parts = this.ctx.multipart();
+    const shouldMockError = !!this.ctx.query.mock_error;
+    const fileSize = parseInt(this.ctx.query.fileSize) || this.app.config.multipart.fileSize;
+
+    const parts = this.ctx.multipart({ limits: { fileSize } });
     const fields = {};
     const files = {};
-
-    const shouldMockError = !!this.ctx.query.mock_error;
 
     for await (const part of parts) {
       if (Array.isArray(part)) {

--- a/test/fixtures/apps/multipart-for-await/app/controller/upload.js
+++ b/test/fixtures/apps/multipart-for-await/app/controller/upload.js
@@ -24,8 +24,9 @@ module.exports = class UploadController extends Controller {
         let content = '';
         await pipeline(part,
           new stream.Writable({
-            write(chunk, encding, callback) {
+            write(chunk, encoding, callback) {
               content += chunk.toString();
+              // console.log('@@', part.filename, part.truncated);
               if (shouldMockError) {
                 return callback(new Error('mock error'));
               }
@@ -33,7 +34,6 @@ module.exports = class UploadController extends Controller {
             },
           }),
         );
-
         files[fieldname] = {
           fileName: filename,
           content,

--- a/test/fixtures/apps/multipart-for-await/config/config.default.js
+++ b/test/fixtures/apps/multipart-for-await/config/config.default.js
@@ -3,7 +3,7 @@
 exports.multipart = {
   fieldSize: 10,
   fieldNameSize: 10,
-  fileSize: 1024,
+  fileSize: 1024 * 1024 * 2,
 };
 
 exports.keys = 'multipart';

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -23,7 +23,7 @@ describe('test/multipart-for-await.test.js', () => {
   beforeEach(() => app.mockCsrf());
   afterEach(mock.restore);
 
-  it('should suport for await...of', async () => {
+  it('should suport for-await-of', async () => {
     const form = formstream();
     form.field('foo', 'bar');
     form.field('love', 'egg');

--- a/test/multipart-for-await.test.js
+++ b/test/multipart-for-await.test.js
@@ -29,6 +29,8 @@ describe('test/multipart-for-await.test.js', () => {
     form.field('love', 'egg');
     form.file('file1', path.join(__dirname, 'fixtures/中文名.js'));
     form.file('file2', path.join(__dirname, 'fixtures/testfile.js'));
+    // will ignore empty file
+    form.buffer('file3', Buffer.from(''), '', 'application/octet-stream');
 
     const res = await urllib.request(host + '/upload', {
       method: 'POST',
@@ -45,6 +47,7 @@ describe('test/multipart-for-await.test.js', () => {
     assert(data.files.file1.content.includes('hello'));
     assert(data.files.file2.fileName === 'testfile.js');
     assert(data.files.file2.content.includes('this is a test file'));
+    assert(!data.files.file3);
   });
 
   it('should auto consumed file stream on error throw', async () => {
@@ -72,6 +75,24 @@ describe('test/multipart-for-await.test.js', () => {
       form.file('file2', path.join(__dirname, 'fixtures/bigfile.js'));
 
       const res = await urllib.request(host + '/upload', {
+        method: 'POST',
+        headers: form.headers(),
+        stream: form,
+        dataType: 'json',
+      });
+
+      const { data, status } = res;
+      assert(status === 413);
+      assert(data.message === 'Reach fileSize limit');
+    });
+
+    it('limit fileSize very small so limit event is miss', async () => {
+      const form = formstream();
+      form.field('foo', 'bar');
+      form.field('love', 'egg');
+      form.file('file2', path.join(__dirname, 'fixtures/bigfile.js'));
+
+      const res = await urllib.request(host + '/upload?fileSize=10', {
         method: 'POST',
         headers: form.headers(),
         stream: form,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

- saveRequestFiles 改为基于 for-await-of 的实现
- getFileStream 由于 limits 的错误类型和 saveRequestFiles 不一致，暂时先不动了